### PR TITLE
Add support for Manjaro

### DIFF
--- a/check_arch_updates
+++ b/check_arch_updates
@@ -15,7 +15,7 @@ then
   distribution="${ID}"
 fi
 
-if [ "${distribution}" = "arch" ] || [ "${distribution}" = "artix" ]
+if [ "${distribution}" = "arch" ] || [ "${distribution}" = "artix" ] || [ "${distribution}" = "manjaro" ]
 then
 
   PACMAN=$(command -v pacman)


### PR DESCRIPTION
Manjaro is based on Arch Linux, identifies in `/etc/os-release` as:

```
NAME="Manjaro Linux"
PRETTY_NAME="Manjaro Linux"
ID=manjaro
ID_LIKE=arch
```